### PR TITLE
Fix bootstrap logic

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,7 +1,7 @@
 <?php
 
 // Detect if we're loaded by an actual run of phpunit
-if (!defined('PHPUNIT_COMPOSER_INSTALL') && !class_exists(\PHPUnit\TextUI\Command::class, false)) {
+if (!defined('PHPUNIT_COMPOSER_INSTALL') || !class_exists('\PHPUnit\TextUI\Command')) {
   return;
 }
 


### PR DESCRIPTION
This fixes two issues.

1. If `PHPUNIT_COMPOSER_INSTALL` is not defined we should exit immediately.
2. If the `\PHPUnit\TextUI\Command` class doesn't exist we can only refer to it with a string.